### PR TITLE
fix: support alphanumeric CNPJ in document validation (Receita Federa…

### DIFF
--- a/v2/document.go
+++ b/v2/document.go
@@ -12,33 +12,40 @@ import (
 // Regexp pattern for CPF and CNPJ.
 var (
 	CPFRegexp  = regexp.MustCompile(`^\d{3}\.?\d{3}\.?\d{3}-?\d{2}$`)
-	CNPJRegexp = regexp.MustCompile(`^\d{2}\.?\d{3}\.?\d{3}/?(:?\d{3}[1-9]|\d{2}[1-9]\d|\d[1-9]\d{2}|[1-9]\d{3})-?\d{2}$`)
+	CNPJRegexp = regexp.MustCompile(`(?i)^[A-Z0-9]{2}\.?[A-Z0-9]{3}\.?[A-Z0-9]{3}/?[A-Z0-9]{4}-?\d{2}$`)
 )
 
 // IsCPF verifies if the given string is a valid CPF document.
 func isCPF(doc string) bool {
 
-	const (
-		size = 9
-		pos  = 10
-	)
+	const size = 9
 
-	return isCPFOrCNPJ(doc, CPFRegexp, size, pos)
+	return isCPFOrCNPJ(doc, CPFRegexp, size)
 }
 
 // IsCNPJ verifies if the given string is a valid CNPJ document.
 func isCNPJ(doc string) bool {
 
-	const (
-		size = 12
-		pos  = 5
-	)
+	const size = 12
 
-	return isCPFOrCNPJ(doc, CNPJRegexp, size, pos)
+	if !CNPJRegexp.MatchString(doc) {
+		return false
+	}
+
+	cleanSeparators(&doc)
+
+	if allEq(doc) {
+		return false
+	}
+
+	dig1 := calculateDigit(doc[:size], []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2})
+	dig2 := calculateDigit(doc[:size+1], []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2})
+
+	return dig1 == int(doc[size]-'0') && dig2 == int(doc[size+1]-'0')
 }
 
-// isCPFOrCNPJ generates the digits for a given CPF or CNPJ and compares it with the original digits.
-func isCPFOrCNPJ(doc string, pattern *regexp.Regexp, size int, position int) bool {
+// isCPFOrCNPJ generates the digits for a given CPF and compares it with the original digits.
+func isCPFOrCNPJ(doc string, pattern *regexp.Regexp, size int) bool {
 
 	if !pattern.MatchString(doc) {
 		return false
@@ -52,12 +59,12 @@ func isCPFOrCNPJ(doc string, pattern *regexp.Regexp, size int, position int) boo
 	}
 
 	d := doc[:size]
-	digit := calculateDigit(d, position)
+	digit := calculateDigit(d, []int{10, 9, 8, 7, 6, 5, 4, 3, 2})
 
-	d = d + digit
-	digit = calculateDigit(d, position+1)
+	d = d + strconv.Itoa(digit)
+	digit2 := calculateDigit(d, []int{11, 10, 9, 8, 7, 6, 5, 4, 3, 2})
 
-	return doc == d+digit
+	return doc == d+strconv.Itoa(digit2)
 }
 
 // cleanNonDigits removes every rune that is not a digit.
@@ -67,6 +74,20 @@ func cleanNonDigits(doc *string) {
 	for _, r := range *doc {
 		if unicode.IsDigit(r) {
 			buf.WriteRune(r)
+		}
+	}
+
+	*doc = buf.String()
+}
+
+// cleanSeparators removes formatting separators (., -, /) while preserving alphanumeric characters.
+// Used for CNPJ which may contain uppercase letters in the new alphanumeric format.
+func cleanSeparators(doc *string) {
+
+	buf := bytes.NewBufferString("")
+	for _, r := range *doc {
+		if r != '.' && r != '-' && r != '/' {
+			buf.WriteRune(unicode.ToUpper(r))
 		}
 	}
 
@@ -86,29 +107,24 @@ func allEq(doc string) bool {
 	return true
 }
 
-// calculateDigit calculates the next digit for the given document.
-func calculateDigit(doc string, position int) string {
+// calculateDigit calculates the next digit for the given document using explicit weights.
+func calculateDigit(doc string, weights []int) int {
 
-	var sum int
-	for _, r := range doc {
-
-		sum += toInt(r) * position
-		position--
-
-		if position < 2 {
-			position = 9
-		}
+	sum := 0
+	for i := 0; i < len(doc); i++ {
+		sum += charValue(doc[i]) * weights[i]
 	}
 
-	sum %= 11
-	if sum < 2 {
-		return "0"
+	rest := sum % 11
+	if rest < 2 {
+		return 0
 	}
-
-	return strconv.Itoa(11 - sum)
+	return 11 - rest
 }
 
-// toInt converts a rune to an int.
-func toInt(r rune) int {
-	return int(r - '0')
+// charValue converts a byte to its numeric value for check digit calculation.
+// Digits 0-9 map to values 0-9; uppercase letters A-Z map to 17-42 (ASCII value minus 48).
+// This follows the Receita Federal IN 2229/2024 specification for alphanumeric CNPJ.
+func charValue(c byte) int {
+	return int(c) - 48
 }

--- a/v2/document_test.go
+++ b/v2/document_test.go
@@ -1,0 +1,164 @@
+package gotag_validator
+
+import "testing"
+
+func TestIsCPF(t *testing.T) {
+	type args struct {
+		doc string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid_cpf_without_formatting",
+			args: args{"02092051059"},
+			want: true,
+		},
+		{
+			name: "valid_cpf_with_formatting",
+			args: args{"020.920.510-59"},
+			want: true,
+		},
+		{
+			name: "invalid_cpf_wrong_check_digits",
+			args: args{"02092051057"},
+			want: false,
+		},
+		{
+			name: "invalid_cpf_all_same_digits",
+			args: args{"222.222.222-22"},
+			want: false,
+		},
+		{
+			name: "invalid_cpf_too_short",
+			args: args{"123456"},
+			want: false,
+		},
+		{
+			name: "invalid_cpf_letters",
+			args: args{"ABCDEF12345"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCPF(tt.args.doc); got != tt.want {
+				t.Errorf("isCPF() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCNPJ(t *testing.T) {
+	type args struct {
+		doc string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// Numeric CNPJs
+		{
+			name: "valid_numeric_cnpj_without_formatting",
+			args: args{"33796617000114"},
+			want: true,
+		},
+		{
+			name: "valid_numeric_cnpj_with_formatting",
+			args: args{"33.796.617/0001-14"},
+			want: true,
+		},
+		{
+			name: "valid_numeric_cnpj_2",
+			args: args{"13661345000138"},
+			want: true,
+		},
+		{
+			name: "valid_numeric_cnpj_3",
+			args: args{"95307061000102"},
+			want: true,
+		},
+		{
+			name: "valid_numeric_cnpj_4",
+			args: args{"38883574000128"},
+			want: true,
+		},
+		{
+			name: "invalid_numeric_cnpj_wrong_check_digit",
+			args: args{"38883574000127"},
+			want: false,
+		},
+		{
+			name: "invalid_numeric_cnpj_wrong_check_digit_2",
+			args: args{"33796617000112"},
+			want: false,
+		},
+		{
+			name: "invalid_numeric_cnpj_all_same_digits",
+			args: args{"11111111111111"},
+			want: false,
+		},
+		// Alphanumeric CNPJs (Receita Federal IN 2229/2024)
+		{
+			name: "valid_alphanumeric_cnpj_3MD06BLA000140",
+			args: args{"3MD06BLA000140"},
+			want: true,
+		},
+		{
+			name: "valid_alphanumeric_cnpj_with_formatting",
+			args: args{"3M.D06.BLA/0001-40"},
+			want: true,
+		},
+		{
+			name: "valid_alphanumeric_cnpj_with_formatting_2",
+			args: args{"9H.V16.8L4/0001-89"},
+			want: true,
+		},
+		{
+			name: "invalid_alphanumeric_cnpj_wrong_check_digit",
+			args: args{"1A2B345C6D7851"},
+			want: false,
+		},
+		{
+			name: "invalid_alphanumeric_cnpj_wrong_check_digit_2",
+			args: args{"LG.EEE.7V1/0001-58"},
+			want: false,
+		},
+		{
+			name: "invalid_alphanumeric_cnpj_all_same_chars",
+			args: args{"AAAAAAAAAAAA14"},
+			want: false,
+		},
+		// Edge cases
+		{
+			name: "invalid_cnpj_too_short",
+			args: args{"1234567890123"},
+			want: false,
+		},
+		{
+			name: "invalid_cnpj_too_long",
+			args: args{"123456789012345"},
+			want: false,
+		},
+		{
+			name: "invalid_cnpj_empty",
+			args: args{""},
+			want: false,
+		},
+		{
+			name: "valid_cnpj_lowercase_alphanumeric",
+			args: args{"3md06bla000140"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCNPJ(tt.args.doc); got != tt.want {
+				t.Errorf("isCNPJ() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…l IN 2229/2024)

- Update CNPJRegexp to accept alphanumeric characters [A-Z0-9] in positions 1-12
- Add cleanSeparators to strip only . - / separators (preserving letters)
- Rewrite isCNPJ to use cleanSeparators instead of cleanNonDigits
- Replace calculateDigit with explicit weights [5,4,3,2,9,8,7,6,5,4,3,2] and [6,5,4,3,2,9,8,7,6,5,4,3,2]
- Replace toInt with charValue using ASCII-48 mapping (A=17, B=18, ..., Z=42)
- Add document_test.go with tests for CPF, numeric CNPJ, and alphanumeric CNPJ